### PR TITLE
feat: Use TapTempo's algorithm

### DIFF
--- a/src/content/TapIn.tsx
+++ b/src/content/TapIn.tsx
@@ -2,48 +2,84 @@ import { useEffect, useState } from "react";
 import { useMetronomeContext } from "./MetronomeContext";
 import { cn } from "../other/cn";
 
+// I'm copying TapTempo.io's algorithm, which converges to an average tempo
+//  See: https://taptempo.io/taptempo.js
+
+let groundZero = 0,
+  lastTap = 0,
+  counter = 0,
+  tapDiff = 0,
+  avgBpm = 0,
+  previousTap = 0,
+  elapsed = 0;
+
+// We do this to keep previous tempo readings from counting for the average of the next reading
+function resetTapper() {
+  groundZero = 0;
+  lastTap = 0;
+  counter = 0;
+  tapDiff = 0;
+  avgBpm = 0;
+  previousTap = 0;
+  elapsed = 0;
+}
+
+function tap() {
+  if (lastTap === 0) {
+    groundZero = new Date().getTime();
+    counter = 0;
+  }
+
+  lastTap = new Date().getTime();
+  elapsed = new Date().getTime() - previousTap;
+
+  previousTap = lastTap;
+  tapDiff = lastTap - groundZero;
+  if (tapDiff !== 0) {
+    avgBpm = Math.round((60_000 * counter) / tapDiff);
+  }
+  counter++;
+
+  if (elapsed > 3_000) lastTap = 0;
+  return avgBpm;
+}
+
 export function TapIn() {
   const { setBpm } = useMetronomeContext();
-  const [tapInTimes, setTapInTimes] = useState<number[]>([]);
-  function updateTapInTimes() {
-    const now = Date.now();
-    const newValues = tapInTimes.slice(-3);
-    newValues.push(now);
-    setTapInTimes(newValues);
-    if (newValues.length === 4) {
-      const sum = newValues[3] - newValues[0];
-      // 4 beats in `sum` seconds ms
-      // since the beggining time, there have been 3 beats
-      const beatsPerMillisecond = 3 / sum;
-      const beatsPerMinute = beatsPerMillisecond * 1000 * 60;
-      setBpm(beatsPerMinute);
-    }
-  }
+
+  // Only used for the orange bar
+  const [ taps, setTaps ] = useState(0);
+
   useEffect(() => {
-    if (tapInTimes.length === 0) return;
+    if (taps === 0) return;
     const interval = setInterval(() => {
-      setTapInTimes([]);
+      setTaps(0);
+      resetTapper();
     }, 3_000);
     return () => clearInterval(interval);
-  }, [tapInTimes]);
+  }, [counter]); // I'm not sure if this is valid in React (this not being a useState)
+
   return (
     <button
       className={
         "relative flex justify-center truncate rounded border border-black dark:border-slate-700 hocus:border-amber-500 dark:hocus:bg-slate-600 hocus:bg-amber-500/10 hocus:shadow-[0_0_0_2px] hocus:shadow-amber-500 hocus:outline-none"
       }
-      onClick={updateTapInTimes}
+      onClick={() => {
+        setTaps(taps+1);
+        setBpm(tap());
+      }}
     >
       <span className="p-1">TAP IN</span>
       <div
         className={cn(
           "absolute bottom-0 left-0 h-[2px] bg-amber-500 transition-all",
           {
-            "w-[0%]": tapInTimes.length === 0,
-            "w-[25%]": tapInTimes.length === 1,
-            "w-[50%]": tapInTimes.length === 2,
-            "w-[75%]": tapInTimes.length === 3,
-            "w-[100%]": tapInTimes.length === 4,
-          },
+            "w-[0%]": taps === 0,
+            "w-[25%]": taps === 1,
+            "w-[50%]": taps === 2,
+            "w-[75%]": taps === 3,
+            "w-[100%]": taps >= 4,
+          }
         )}
       />
     </button>


### PR DESCRIPTION
Hi again :p

I made another adjustment and forgot to send the PR, this time for the Tap in feature.
I frequently use [TapTempo](https://taptempo.io), which I noticed converges more smoothly to the approximated tempo, so I copied its algorithm to the app :)
I think the difference is that currently the app counts the average bpm in the last four beats, and this new function counts the average since the very first tap until the current one. The average count still resets after 3 seconds to allow making a new tempo measurement.

As one comment says, I'm not sure if the way I implemented this is the "correct React way," but trying to use state variables was making more trouble than good.